### PR TITLE
[draft] Test Step Persistence of cwd in jobs

### DIFF
--- a/.github/workflows/try-step-persistence.yml
+++ b/.github/workflows/try-step-persistence.yml
@@ -1,0 +1,16 @@
+# Tests if the current working directory resets between steps
+name: Test Step Persistence of pwd
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  dump-context:
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: mkdir -p a/b/c
+      - run: ls
+      - run: cd a
+      - run: pwd


### PR DESCRIPTION
This was to double-check that the working directory of a step `run` doesn't carryover into the next step's `run`.

It doesn't.