### PR TITLE
[draft] check python

### DIFF
--- a/.github/workflows/check-python.yml
+++ b/.github/workflows/check-python.yml
@@ -1,0 +1,13 @@
+name: Check if python can be used without setup-python
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: which python
+      - run: python -V


### PR DESCRIPTION
check if it is possible to use python without the setup-python action. It looks like it ought to be because the runner image says python is present

https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md