### PR TITLE
[draft] add workflow to test failure(), cancelled(), wrt jobs that timeout

### DIFF
--- a/.github/workflows/test-matrix-jobs-result.yml
+++ b/.github/workflows/test-matrix-jobs-result.yml
@@ -1,0 +1,162 @@
+name: Test Matrix Job Results
+
+on:
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  # Matrix job where one succeeds and one fails
+  matrix-success-and-failure:
+    name: Matrix Success/Failure (Shard ${{ matrix.shard }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shard: [1, 2]
+      fail-fast: false
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run shard
+        run: |
+          echo "Running shard ${{ matrix.shard }}"
+          if [ "${{ matrix.shard }}" == "1" ]; then
+            echo "Shard 1: Will succeed"
+            exit 0
+          else
+            echo "Shard 2: Will fail"
+            exit 1
+          fi
+
+  # Reporter for success/failure matrix job
+  report-success-failure:
+    name: Report Success/Failure Matrix Status
+    runs-on: ubuntu-latest
+    needs: matrix-success-and-failure
+    if: always()
+
+    steps:
+      - name: Check if success() is true
+        if: success()
+        run: echo "✓ success() evaluates to TRUE"
+
+      - name: Check if success() is false
+        if: ${{ !success() }}
+        run: echo "✗ success() evaluates to FALSE"
+
+      - name: Check if failure() is true
+        if: failure()
+        run: echo "✓ failure() evaluates to TRUE"
+
+      - name: Check if failure() is false
+        if: ${{ !failure() }}
+        run: echo "✗ failure() evaluates to FALSE"
+
+      - name: Check if cancelled() is true
+        if: cancelled()
+        run: echo "✓ cancelled() evaluates to TRUE"
+
+      - name: Check if cancelled() is false
+        if: ${{ !cancelled() }}
+        run: echo "✗ cancelled() evaluates to FALSE"
+
+      - name: Report unified status
+        if: always()
+        run: |
+          echo "=== Matrix Success/Failure Status Report ==="
+          echo ""
+          echo "Unified matrix job result: ${{ needs.matrix-success-and-failure.result }}"
+          echo ""
+          echo "Full needs context:"
+          echo '${{ toJSON(needs) }}'
+          echo ""
+          echo "Expected behavior:"
+          echo "- Shard 1: success"
+          echo "- Shard 2: failure"
+          echo "- Unified result: failure (because one shard failed)"
+          echo "- failure() should be TRUE"
+          echo "- success() should be FALSE"
+
+  # Matrix job where one succeeds and one times out
+  matrix-success-and-timeout:
+    name: Matrix Success/Timeout (Shard ${{ matrix.shard }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    strategy:
+      matrix:
+        shard: [1, 2]
+      fail-fast: false
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run shard
+        run: |
+          echo "Running shard ${{ matrix.shard }}"
+          if [ "${{ matrix.shard }}" == "1" ]; then
+            echo "Shard 1: Will succeed (10 seconds)"
+            sleep 10
+            echo "Shard 1: Completed successfully"
+          else
+            echo "Shard 2: Will timeout (90 seconds, timeout is 60)"
+            sleep 90
+            echo "This should never print due to timeout"
+          fi
+
+      - name: Post-timeout step (runs on failure or cancellation)
+        if: failure() || cancelled()
+        run: |
+          echo "Shard ${{ matrix.shard }}: This runs if job failed or was cancelled"
+          echo "Job status: ${{ job.status }}"
+
+  # Reporter for success/timeout matrix job
+  report-success-timeout:
+    name: Report Success/Timeout Matrix Status
+    runs-on: ubuntu-latest
+    needs: matrix-success-and-timeout
+    if: always()
+
+    steps:
+      - name: Check if success() is true
+        if: success()
+        run: echo "✓ success() evaluates to TRUE"
+
+      - name: Check if success() is false
+        if: ${{ !success() }}
+        run: echo "✗ success() evaluates to FALSE"
+
+      - name: Check if failure() is true
+        if: failure()
+        run: echo "✓ failure() evaluates to TRUE"
+
+      - name: Check if failure() is false
+        if: ${{ !failure() }}
+        run: echo "✗ failure() evaluates to FALSE"
+
+      - name: Check if cancelled() is true
+        if: cancelled()
+        run: echo "✓ cancelled() evaluates to TRUE"
+
+      - name: Check if cancelled() is false
+        if: ${{ !cancelled() }}
+        run: echo "✗ cancelled() evaluates to FALSE"
+
+      - name: Report unified status
+        if: always()
+        run: |
+          echo "=== Matrix Success/Timeout Status Report ==="
+          echo ""
+          echo "Unified matrix job result: ${{ needs.matrix-success-and-timeout.result }}"
+          echo ""
+          echo "Full needs context:"
+          echo '${{ toJSON(needs) }}'
+          echo ""
+          echo "Expected behavior:"
+          echo "- Shard 1: success"
+          echo "- Shard 2: cancelled (due to timeout)"
+          echo "- Unified result: failure (because one shard was cancelled)"
+          echo "- failure() should be TRUE"
+          echo "- success() should be FALSE"
+          echo "- cancelled() might be TRUE (if timeout is treated as cancellation)"

--- a/.github/workflows/test-matrix-jobs-result.yml
+++ b/.github/workflows/test-matrix-jobs-result.yml
@@ -37,30 +37,6 @@ jobs:
     if: always()
 
     steps:
-      - name: Check if success() is true
-        if: success()
-        run: echo "✓ success() evaluates to TRUE"
-
-      - name: Check if success() is false
-        if: ${{ !success() }}
-        run: echo "✗ success() evaluates to FALSE"
-
-      - name: Check if failure() is true
-        if: failure()
-        run: echo "✓ failure() evaluates to TRUE"
-
-      - name: Check if failure() is false
-        if: ${{ !failure() }}
-        run: echo "✗ failure() evaluates to FALSE"
-
-      - name: Check if cancelled() is true
-        if: cancelled()
-        run: echo "✓ cancelled() evaluates to TRUE"
-
-      - name: Check if cancelled() is false
-        if: ${{ !cancelled() }}
-        run: echo "✗ cancelled() evaluates to FALSE"
-
       - name: Report unified status
         if: always()
         run: |
@@ -105,12 +81,6 @@ jobs:
             echo "This should never print due to timeout"
           fi
 
-      - name: Post-timeout step (runs on failure or cancellation)
-        if: failure() || cancelled()
-        run: |
-          echo "Shard ${{ matrix.shard }}: This runs if job failed or was cancelled"
-          echo "Job status: ${{ job.status }}"
-
   # Reporter for success/timeout matrix job
   report-success-timeout:
     name: Report Success/Timeout Matrix Status
@@ -119,30 +89,6 @@ jobs:
     if: always()
 
     steps:
-      - name: Check if success() is true
-        if: success()
-        run: echo "✓ success() evaluates to TRUE"
-
-      - name: Check if success() is false
-        if: ${{ !success() }}
-        run: echo "✗ success() evaluates to FALSE"
-
-      - name: Check if failure() is true
-        if: failure()
-        run: echo "✓ failure() evaluates to TRUE"
-
-      - name: Check if failure() is false
-        if: ${{ !failure() }}
-        run: echo "✗ failure() evaluates to FALSE"
-
-      - name: Check if cancelled() is true
-        if: cancelled()
-        run: echo "✓ cancelled() evaluates to TRUE"
-
-      - name: Check if cancelled() is false
-        if: ${{ !cancelled() }}
-        run: echo "✗ cancelled() evaluates to FALSE"
-
       - name: Report unified status
         if: always()
         run: |

--- a/.github/workflows/test-rollup-jobs.yml
+++ b/.github/workflows/test-rollup-jobs.yml
@@ -1,4 +1,4 @@
-name: Test Timeout Minutes
+name: Test Rollup Jobs
 
 on:
   pull_request:
@@ -8,9 +8,6 @@ jobs:
   timeout-job:
     runs-on: ubuntu-latest
     timeout-minutes: 1
-    outputs:
-      shard-1-result: ${{ steps.set-result-1.outputs.result }}
-      shard-2-result: ${{ steps.set-result-2.outputs.result }}
 
     steps:
       - name: Long running step (will timeout)

--- a/.github/workflows/test-rollup-jobs.yml
+++ b/.github/workflows/test-rollup-jobs.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, master]
 
 jobs:
+  # always times out
   timeout-job:
     runs-on: ubuntu-latest
     timeout-minutes: 1
@@ -14,13 +15,19 @@ jobs:
         run: |
           sleep 90
 
+  # this rollup job shows that "cancelled()" works counter-intuitively.
+  # Even though the dependent job timed out and was cancelled,
+  # this job is skipped (because `cancelled()` refers to this job's status, so it is not `true`)
   timeout-job-incorrect-result:
     runs-on: ubuntu-latest
     needs: timeout-job
-    if: ${{ failure() || cancelled() }}
+    if: ${{ cancelled() }}
     steps:
       - run: exit 1
 
+  # this rollup job correctly checks the status of the dependent job.
+  # this job runs "always" but fails ('exit 1') if `needs.tieout-job.result` is
+  # a failure or cancelled (ie "not success")
   timeout-job-correct-result:
     runs-on: ubuntu-latest
     needs: timeout-job
@@ -29,11 +36,14 @@ jobs:
       - if: ${{ needs.timeout-job.result != 'success' }}
         run: exit 1
 
+  # This job always fails
   failure-job:
     runs-on: ubuntu-latest
     steps:
       - run: exit 1
 
+  # This rollup job shows that `if failure()` works as we expect, unlike `if cancelled()`:
+  # it is "true" bc the dependent job failed
   failure-job-result:
     runs-on: ubuntu-latest
     needs: failure-job
@@ -41,21 +51,8 @@ jobs:
     steps:
       - run: exit 1
 
-  failure-job-robust-result:
-    runs-on: ubuntu-latest
-    needs: failure-job
-    if: ${{ always() }}
-    steps:
-      - if: ${{ needs.failure-job.result != 'success' }}
-        run: exit 1
-
-  rollup-job-incorrect-result:
-    runs-on: ubuntu-latest
-    needs: [failure-job, timeout-job]
-    if: ${{ failure() || cancelled() }}
-    steps:
-      - run: exit 1
-
+  # This rollup job depends on both the failure and timeout jobs.
+  # It uses the robust technique of always running and checking the result of the dependent job(s)
   rollup-job-correct-result:
     runs-on: ubuntu-latest
     needs: [failure-job, timeout-job]

--- a/.github/workflows/test-rollup-jobs.yml
+++ b/.github/workflows/test-rollup-jobs.yml
@@ -36,6 +36,14 @@ jobs:
       - if: ${{ needs.timeout-job.result != 'success' }}
         run: exit 1
 
+  # alt approach to the job above using the result check in the job.if
+  timeout-job-correct-result-alt:
+    runs-on: ubuntu-latest
+    needs: timeout-job
+    if: ${{ needs.timeout-job.result != 'success' }}
+    steps:
+      - run: exit 1
+
   # This job always fails
   failure-job:
     runs-on: ubuntu-latest

--- a/.github/workflows/timeout-minutes.yml
+++ b/.github/workflows/timeout-minutes.yml
@@ -35,7 +35,7 @@ jobs:
             echo "This should never print due to timeout"
           else
             echo "Shard 2: Sleeping for 10 seconds (will complete successfully)"
-            sleep 90
+            sleep 10
             echo "Shard 2: Completed successfully"
           fi
 
@@ -76,10 +76,10 @@ jobs:
           echo "result=${{ job.status }}" >> $GITHUB_OUTPUT
 
   dependent-job:
-    name: Dependent Job (Runs on Failure/Cancellation)
+    name: Dependent Job (Runs on non-success)
     runs-on: ubuntu-latest
     needs: sharded-job
-    if: failure() || cancelled()
+    if: ${{ needs.sharded-job.result != 'success' }}
 
     steps:
       - name: Check sharded job status

--- a/.github/workflows/timeout-minutes.yml
+++ b/.github/workflows/timeout-minutes.yml
@@ -5,155 +5,64 @@ on:
     branches: [main, master]
 
 jobs:
-  sharded-job:
-    name: Sharded Job (Shard ${{ matrix.shard }})
+  timeout-job:
     runs-on: ubuntu-latest
     timeout-minutes: 1
     outputs:
       shard-1-result: ${{ steps.set-result-1.outputs.result }}
       shard-2-result: ${{ steps.set-result-2.outputs.result }}
-    strategy:
-      matrix:
-        shard: [1, 2]
-      fail-fast: false
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Initial step
+      - name: Long running step (will timeout)
         run: |
-          echo "Starting shard ${{ matrix.shard }}"
-          echo "This step should complete normally"
+          sleep 90
 
-      - name: Long running step (will timeout for shard 1 only)
-        run: |
-          echo "Shard ${{ matrix.shard }}: Starting operation"
-          if [ "${{ matrix.shard }}" == "1" ]; then
-            echo "Shard 1: Sleeping for 90 seconds (timeout is 60 seconds)"
-            sleep 90
-            echo "This should never print due to timeout"
-          else
-            echo "Shard 2: Sleeping for 10 seconds (will complete successfully)"
-            sleep 10
-            echo "Shard 2: Completed successfully"
-          fi
+  timeout-job-incorrect-result:
+    runs-on: ubuntu-latest
+    needs: timeout-job
+    if: ${{ failure() || cancelled() }}
+    steps:
+      - run: exit 1
 
-      - name: Step after long operation
-        run: |
-          echo "Shard ${{ matrix.shard }}: This step runs after the long operation"
-          if [ "${{ matrix.shard }}" == "1" ]; then
-            echo "Shard 1: This should NOT execute due to timeout"
-          else
-            echo "Shard 2: This SHOULD execute normally"
-          fi
-
-      - name: Cleanup step (runs on failure or cancellation)
-        if: failure() || cancelled()
-        run: |
-          echo "Shard ${{ matrix.shard }}: CLEANUP - This runs if job failed or was cancelled"
-          echo "Job status: ${{ job.status }}"
-          echo "Testing if this executes after timeout cancellation"
-
-      - name: Another conditional step (runs on failure or cancellation)
-        if: failure() || cancelled()
-        run: |
-          echo "Shard ${{ matrix.shard }}: CONDITIONAL - Another step that should run on timeout"
-          echo "Verifying multiple conditional steps work after timeout"
-
-      - name: Set shard 1 result
-        id: set-result-1
-        if: always() && matrix.shard == 1
-        run: |
-          echo "Shard 1 final status: ${{ job.status }}"
-          echo "result=${{ job.status }}" >> $GITHUB_OUTPUT
-
-      - name: Set shard 2 result
-        id: set-result-2
-        if: always() && matrix.shard == 2
-        run: |
-          echo "Shard 2 final status: ${{ job.status }}"
-          echo "result=${{ job.status }}" >> $GITHUB_OUTPUT
+  timeout-job-correct-result:
+    runs-on: ubuntu-latest
+    needs: timeout-job
+    if: ${{ always() }}
+    steps:
+      - if: ${{ needs.timeout-job.result != 'success' }}
+        run: exit 1
 
   failure-job:
-    name: Failure-reporter Job
     runs-on: ubuntu-latest
-    needs: sharded-job
+    steps:
+      - run: exit 1
+
+  failure-job-result:
+    runs-on: ubuntu-latest
+    needs: failure-job
     if: ${{ failure() }}
     steps:
       - run: exit 1
 
-  dependent-job:
-    name: Dependent Job (Runs on non-success)
+  failure-job-robust-result:
     runs-on: ubuntu-latest
-    needs: sharded-job
-    if: ${{ always() && needs.sharded-job.result != 'success' }}
-
+    needs: failure-job
+    if: ${{ always() }}
     steps:
-      - name: Check sharded job status
-        run: |
-          echo "Dependent job is running!"
-          echo "This job should run because sharded-job timed out"
-          echo "Needs context: ${{ toJSON(needs) }}"
+      - if: ${{ needs.failure-job.result != 'success' }}
+        run: exit 1
 
-      - name: Verify timeout behavior
-        run: |
-          echo "Testing if dependent job runs when parent times out"
-          echo "Expected: This should execute because sharded-job was cancelled due to timeout"
-
-      - name: Final verification
-        run: |
-          echo "Dependent job executed because at least one shard timed out (shard 1)"
-          echo "Shard 2 should have completed successfully"
-
-  status-reporter:
-    name: Status Reporter (Always Runs)
+  rollup-job-incorrect-result:
     runs-on: ubuntu-latest
-    needs: sharded-job
-    if: always()
-
+    needs: [failure-job, timeout-job]
+    if: ${{ failure() || cancelled() }}
     steps:
-      - name: Check if success() is true
-        if: success()
-        run: echo "✓ success() evaluates to TRUE"
+      - run: exit 1
 
-      - name: Check if success() is false
-        if: ${{ !success() }}
-        run: echo "✗ success() evaluates to FALSE"
-
-      - name: Check if failure() is true
-        if: failure()
-        run: echo "✓ failure() evaluates to TRUE"
-
-      - name: Check if failure() is false
-        if: ${{ !failure() }}
-        run: echo "✗ failure() evaluates to FALSE"
-
-      - name: Check if cancelled() is true
-        if: cancelled()
-        run: echo "✓ cancelled() evaluates to TRUE"
-
-      - name: Check if cancelled() is false
-        if: ${{ !cancelled() }}
-        run: echo "✗ cancelled() evaluates to FALSE"
-
-      - name: Report all shard statuses
-        if: always()
-        run: |
-          echo ""
-          echo "=== Shard Status Report ==="
-          echo ""
-          echo "Overall sharded job result: ${{ needs.sharded-job.result }}"
-          echo ""
-          echo "Individual shard results:"
-          echo "- Shard 1 result: ${{ needs.sharded-job.outputs.shard-1-result }}"
-          echo "- Shard 2 result: ${{ needs.sharded-job.outputs.shard-2-result }}"
-          echo ""
-          echo "Full needs context:"
-          echo '${{ toJSON(needs) }}'
-          echo ""
-          echo "Expected behavior:"
-          echo "- Shard 1: Should be 'cancelled' due to timeout"
-          echo "- Shard 2: Should be 'success'"
-          echo "- Overall job: Should be 'failure' because one shard failed"
-          echo "- failure() should be true, success() should be false"
+  rollup-job-correct-result:
+    runs-on: ubuntu-latest
+    needs: [failure-job, timeout-job]
+    if: ${{ always() }}
+    steps:
+      - if: ${{ needs.failure-job.result != 'success' || needs.timeout-job.result != 'success' }}
+        run: exit 1

--- a/.github/workflows/timeout-minutes.yml
+++ b/.github/workflows/timeout-minutes.yml
@@ -35,7 +35,7 @@ jobs:
             echo "This should never print due to timeout"
           else
             echo "Shard 2: Sleeping for 10 seconds (will complete successfully)"
-            sleep 10
+            sleep 90
             echo "Shard 2: Completed successfully"
           fi
 

--- a/.github/workflows/timeout-minutes.yml
+++ b/.github/workflows/timeout-minutes.yml
@@ -31,8 +31,7 @@ jobs:
           echo "Shard ${{ matrix.shard }}: Starting operation"
           if [ "${{ matrix.shard }}" == "1" ]; then
             echo "Shard 1: Sleeping for 90 seconds (timeout is 60 seconds)"
-            # sleep 90
-            exit 1
+            sleep 90
             echo "This should never print due to timeout"
           else
             echo "Shard 2: Sleeping for 10 seconds (will complete successfully)"

--- a/.github/workflows/timeout-minutes.yml
+++ b/.github/workflows/timeout-minutes.yml
@@ -9,6 +9,9 @@ jobs:
     name: Sharded Job (Shard ${{ matrix.shard }})
     runs-on: ubuntu-latest
     timeout-minutes: 1
+    outputs:
+      shard-1-result: ${{ steps.set-result-1.outputs.result }}
+      shard-2-result: ${{ steps.set-result-2.outputs.result }}
     strategy:
       matrix:
         shard: [1, 2]
@@ -23,17 +26,27 @@ jobs:
           echo "Starting shard ${{ matrix.shard }}"
           echo "This step should complete normally"
 
-      - name: Long running step (will timeout)
+      - name: Long running step (will timeout for shard 1 only)
         run: |
-          echo "Shard ${{ matrix.shard }}: Starting long operation that will exceed timeout"
-          echo "Sleeping for 90 seconds (timeout is 60 seconds)"
-          sleep 90
-          echo "This should never print due to timeout"
+          echo "Shard ${{ matrix.shard }}: Starting operation"
+          if [ "${{ matrix.shard }}" == "1" ]; then
+            echo "Shard 1: Sleeping for 90 seconds (timeout is 60 seconds)"
+            sleep 90
+            echo "This should never print due to timeout"
+          else
+            echo "Shard 2: Sleeping for 10 seconds (will complete successfully)"
+            sleep 10
+            echo "Shard 2: Completed successfully"
+          fi
 
-      - name: Step after timeout (should not run normally)
+      - name: Step after long operation
         run: |
-          echo "Shard ${{ matrix.shard }}: This step runs after the timeout step"
-          echo "This should not execute in normal flow"
+          echo "Shard ${{ matrix.shard }}: This step runs after the long operation"
+          if [ "${{ matrix.shard }}" == "1" ]; then
+            echo "Shard 1: This should NOT execute due to timeout"
+          else
+            echo "Shard 2: This SHOULD execute normally"
+          fi
 
       - name: Cleanup step (runs on failure or cancellation)
         if: failure() || cancelled()
@@ -47,6 +60,20 @@ jobs:
         run: |
           echo "Shard ${{ matrix.shard }}: CONDITIONAL - Another step that should run on timeout"
           echo "Verifying multiple conditional steps work after timeout"
+
+      - name: Set shard 1 result
+        id: set-result-1
+        if: always() && matrix.shard == 1
+        run: |
+          echo "Shard 1 final status: ${{ job.status }}"
+          echo "result=${{ job.status }}" >> $GITHUB_OUTPUT
+
+      - name: Set shard 2 result
+        id: set-result-2
+        if: always() && matrix.shard == 2
+        run: |
+          echo "Shard 2 final status: ${{ job.status }}"
+          echo "result=${{ job.status }}" >> $GITHUB_OUTPUT
 
   dependent-job:
     name: Dependent Job (Runs on Failure/Cancellation)
@@ -68,5 +95,57 @@ jobs:
 
       - name: Final verification
         run: |
-          echo "All shards timed out, and this dependent job executed successfully"
-          echo "Timeout-minutes test complete"
+          echo "Dependent job executed because at least one shard timed out (shard 1)"
+          echo "Shard 2 should have completed successfully"
+
+  status-reporter:
+    name: Status Reporter (Always Runs)
+    runs-on: ubuntu-latest
+    needs: sharded-job
+    if: always()
+
+    steps:
+      - name: Check if success() is true
+        if: success()
+        run: echo "✓ success() evaluates to TRUE"
+
+      - name: Check if success() is false
+        if: ${{ !success() }}
+        run: echo "✗ success() evaluates to FALSE"
+
+      - name: Check if failure() is true
+        if: failure()
+        run: echo "✓ failure() evaluates to TRUE"
+
+      - name: Check if failure() is false
+        if: ${{ !failure() }}
+        run: echo "✗ failure() evaluates to FALSE"
+
+      - name: Check if cancelled() is true
+        if: cancelled()
+        run: echo "✓ cancelled() evaluates to TRUE"
+
+      - name: Check if cancelled() is false
+        if: ${{ !cancelled() }}
+        run: echo "✗ cancelled() evaluates to FALSE"
+
+      - name: Report all shard statuses
+        if: always()
+        run: |
+          echo ""
+          echo "=== Shard Status Report ==="
+          echo ""
+          echo "Overall sharded job result: ${{ needs.sharded-job.result }}"
+          echo ""
+          echo "Individual shard results:"
+          echo "- Shard 1 result: ${{ needs.sharded-job.outputs.shard-1-result }}"
+          echo "- Shard 2 result: ${{ needs.sharded-job.outputs.shard-2-result }}"
+          echo ""
+          echo "Full needs context:"
+          echo '${{ toJSON(needs) }}'
+          echo ""
+          echo "Expected behavior:"
+          echo "- Shard 1: Should be 'cancelled' due to timeout"
+          echo "- Shard 2: Should be 'success'"
+          echo "- Overall job: Should be 'failure' because one shard failed"
+          echo "- failure() should be true, success() should be false"

--- a/.github/workflows/timeout-minutes.yml
+++ b/.github/workflows/timeout-minutes.yml
@@ -31,7 +31,8 @@ jobs:
           echo "Shard ${{ matrix.shard }}: Starting operation"
           if [ "${{ matrix.shard }}" == "1" ]; then
             echo "Shard 1: Sleeping for 90 seconds (timeout is 60 seconds)"
-            sleep 90
+            # sleep 90
+            exit 1
             echo "This should never print due to timeout"
           else
             echo "Shard 2: Sleeping for 10 seconds (will complete successfully)"
@@ -74,6 +75,14 @@ jobs:
         run: |
           echo "Shard 2 final status: ${{ job.status }}"
           echo "result=${{ job.status }}" >> $GITHUB_OUTPUT
+
+  failure-job:
+    name: Failure-reporter Job (Runs on non-success)
+    runs-on: ubuntu-latest
+    needs: sharded-job
+    if: ${{ failure() }}
+    steps:
+      - run: exit 1
 
   dependent-job:
     name: Dependent Job (Runs on non-success)

--- a/.github/workflows/timeout-minutes.yml
+++ b/.github/workflows/timeout-minutes.yml
@@ -1,0 +1,72 @@
+name: Test Timeout Minutes
+
+on:
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  sharded-job:
+    name: Sharded Job (Shard ${{ matrix.shard }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    strategy:
+      matrix:
+        shard: [1, 2]
+      fail-fast: false
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Initial step
+        run: |
+          echo "Starting shard ${{ matrix.shard }}"
+          echo "This step should complete normally"
+
+      - name: Long running step (will timeout)
+        run: |
+          echo "Shard ${{ matrix.shard }}: Starting long operation that will exceed timeout"
+          echo "Sleeping for 90 seconds (timeout is 60 seconds)"
+          sleep 90
+          echo "This should never print due to timeout"
+
+      - name: Step after timeout (should not run normally)
+        run: |
+          echo "Shard ${{ matrix.shard }}: This step runs after the timeout step"
+          echo "This should not execute in normal flow"
+
+      - name: Cleanup step (runs on failure or cancellation)
+        if: failure() || cancelled()
+        run: |
+          echo "Shard ${{ matrix.shard }}: CLEANUP - This runs if job failed or was cancelled"
+          echo "Job status: ${{ job.status }}"
+          echo "Testing if this executes after timeout cancellation"
+
+      - name: Another conditional step (runs on failure or cancellation)
+        if: failure() || cancelled()
+        run: |
+          echo "Shard ${{ matrix.shard }}: CONDITIONAL - Another step that should run on timeout"
+          echo "Verifying multiple conditional steps work after timeout"
+
+  dependent-job:
+    name: Dependent Job (Runs on Failure/Cancellation)
+    runs-on: ubuntu-latest
+    needs: sharded-job
+    if: failure() || cancelled()
+
+    steps:
+      - name: Check sharded job status
+        run: |
+          echo "Dependent job is running!"
+          echo "This job should run because sharded-job timed out"
+          echo "Needs context: ${{ toJSON(needs) }}"
+
+      - name: Verify timeout behavior
+        run: |
+          echo "Testing if dependent job runs when parent times out"
+          echo "Expected: This should execute because sharded-job was cancelled due to timeout"
+
+      - name: Final verification
+        run: |
+          echo "All shards timed out, and this dependent job executed successfully"
+          echo "Timeout-minutes test complete"

--- a/.github/workflows/timeout-minutes.yml
+++ b/.github/workflows/timeout-minutes.yml
@@ -77,7 +77,7 @@ jobs:
           echo "result=${{ job.status }}" >> $GITHUB_OUTPUT
 
   failure-job:
-    name: Failure-reporter Job (Runs on non-success)
+    name: Failure-reporter Job
     runs-on: ubuntu-latest
     needs: sharded-job
     if: ${{ failure() }}
@@ -88,7 +88,7 @@ jobs:
     name: Dependent Job (Runs on non-success)
     runs-on: ubuntu-latest
     needs: sharded-job
-    if: ${{ needs.sharded-job.result != 'success' }}
+    if: ${{ always() && needs.sharded-job.result != 'success' }}
 
     steps:
       - name: Check sharded job status


### PR DESCRIPTION
This PR explores how to the `failure()` or `cancelled()` expressions work, particularly with respect to a workflow job that times out because it exceeds `timeout-minutes`.

This shows that in order for a "roll-up" job to correctly _run and fail_ if a dependent job timed out, that roll-up job must use the `always()` expression and check the dependent job status directly.

```
if: ${{ always() && needs.dependent-job.result != 'success' }}
```

Separately, the "test-matrix-jobs-result" workflow confirms that matrix (sharded) jobs report a single unified status like so:
  * if any job failed, result is "failed"
  * if any job cancelled, result is "cancelled"